### PR TITLE
Propagate 'close' event properly from ssh client

### DIFF
--- a/src/transport/ssh.js
+++ b/src/transport/ssh.js
@@ -85,6 +85,7 @@ export default function connectSSH(options) {
     .on('keyboard-interactive', onKeyboardInteractive)
     .on('ready', onReady)
     .on('error', (error) => { transport.emit('error', error.level); })
+    .on('close', () => { transport.emit('close'); })
     .connect(Object.assign({ tryKeyboard: true }, mergedOpts));
 
   transport.close = () => { client.end(); };

--- a/test/transport/ssh.spec.js
+++ b/test/transport/ssh.spec.js
@@ -65,6 +65,31 @@ describe('connectSSH', () => {
     });
   });
 
+  describe('emits "close" on transport stream', () => {
+    beforeEach(() => {
+      connectSSH({ client })
+        .on('data', dataSpy)
+        .on('error', errorSpy)
+        .on('close', closeSpy);
+    });
+
+    it('on client close', () => {
+      client.emit('close');
+
+      expect(closeSpy).to.have.been.calledOnce();
+    });
+
+    it('on ssh stream close', () => {
+      const sshStream = new Duplex({ read: () => {} });
+      client.shell.callsArgWith(1, null, sshStream);
+
+      client.emit('ready');
+      sshStream.emit('close');
+
+      expect(closeSpy).to.have.been.calledOnce();
+    });
+  });
+
   describe('stream', () => {
     beforeEach(() => {
       connectSSH({ client })


### PR DESCRIPTION
It seems the events from the ssh client doesn't propagate properly now.

A nice way to reproduce this is to connect over ssh, and turn of the ssh server. Currently, the 'close' event doesn't trigger. 