### PR TITLE
rpc: add response body to promise rejection on error

### DIFF
--- a/src/xapi/exc.js
+++ b/src/xapi/exc.js
@@ -9,7 +9,7 @@ export const METHOD_NOT_FOUND = -32601;
 
 
 export class XAPIError extends Error {
-  constructor(code, reason) {
+  constructor(code, reason, data) {
     if (typeof reason !== 'string') {
       throw new Error('Reason for XAPIError must be a string');
     }
@@ -20,6 +20,9 @@ export class XAPIError extends Error {
 
     super(reason);
     this.code = code;
+    if (data !== undefined) {
+      this.data = data;
+    }
   }
 }
 

--- a/src/xapi/rpc.js
+++ b/src/xapi/rpc.js
@@ -18,7 +18,7 @@ const VERSION = '2.0';
 /*
  * Collapse "Value" into parent + skip lowercase props
  */
-function collapse(data) {
+export function collapse(data) {
   if (Array.isArray(data)) {
     return data.map(collapse);
   } else if (isScalar(data)) {
@@ -111,11 +111,12 @@ function assertValidCommandResponse(response) {
 
   switch (root.status) {
     case 'Error': {
-      const { Error, Reason, XPath } = collapse(root);
+      const body = collapse(root);
+      const { Error, Reason, XPath } = body;
       if (XPath) {
         throw new InvalidPathError(Reason, XPath);
       }
-      throw new XAPIError(UNKNOWN_ERROR, Error || Reason);
+      throw new XAPIError(UNKNOWN_ERROR, Error || Reason, body);
     }
     case 'ParameterError':
       throw new ParameterError();

--- a/test/xapi/rpc.spec.js
+++ b/test/xapi/rpc.spec.js
@@ -1,4 +1,5 @@
 import {
+  collapse,
   createCommandResponse,
   createGetResponse,
   createRequest,
@@ -105,6 +106,36 @@ describe('xapi/rpc', () => {
 
       expect(() => createCommandResponse(data))
         .to.throw(XAPIError, 'No Encryption optionkey is installed');
+    });
+
+    it('propagates Error body', () => {
+      const data = JSON.parse(`
+        {
+          "CommandResponse":{
+            "OptionKeyRemoveResult":{
+              "status":"Error",
+              "Error":{
+                "Value":"No Encryption optionkey is installed"
+              },
+              "Messages":[
+                {
+                  "Message":{"Value":"Message 1"}
+                },
+                {
+                  "Message":{"Value":"Message 2"}
+                }
+              ]
+            }
+          }
+        }
+      `);
+
+      expect(() => createCommandResponse(data)).to.throw(
+        XAPIError,
+        'No Encryption optionkey is installed',
+      )
+        .property('data')
+        .deep.equal(collapse(data.CommandResponse.OptionKeyRemoveResult));
     });
 
     describe('handles invalid structure', () => {


### PR DESCRIPTION
This is useful for the cases where an error fails with additional
detail.