### PR TITLE
fix #33: Expose feedback registration promise

### DIFF
--- a/src/xapi/feedback.js
+++ b/src/xapi/feedback.js
@@ -123,6 +123,8 @@ export default class Feedback {
    *
    * @param {Array|string} path - Path to subscribe to
    * @param {function} listener - Listener invoked on feedback
+   * @return {function()} - Feedback cancellation function
+   * @property {Promise<{ Id: number}>} registration - Promise for successful feedback registration
    */
   on(path, listener) {
     log.info(`new feedback listener on: ${path}`);
@@ -144,6 +146,7 @@ export default class Feedback {
       this.eventEmitter.removeListener(eventPath, listener);
     };
 
+    off.registration = registration;
     return off;
   }
 
@@ -153,6 +156,8 @@ export default class Feedback {
    *
    * @param {Array|string} path - Path to subscribe to
    * @param {function} listener - Listener invoked on feedback
+   * @return {function()} - Feedback cancellation function
+   * @property {Promise<{ Id: number}>} registration - Promise for successful feedback registration
    */
   once(path, listener) {
     let off;

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,4 +1,5 @@
 --recursive
 --reporter dot
 --require babel-register
+--require babel-polyfill
 --require ./test/setup.js

--- a/test/xapi/feedback.spec.js
+++ b/test/xapi/feedback.spec.js
@@ -141,6 +141,20 @@ describe('Feedback', () => {
       expect(spy).to.not.have.been.called();
     });
 
+    it('off handler contains registration promise', async () => {
+      const spy = sandbox.spy();
+
+      const regs = await Promise.all([
+        feedback.on('Status/Audio/Volume', spy).registration,
+        feedback.on('Status/Audio/Volume', spy).registration,
+      ]);
+
+      expect(regs).to.deep.equal([
+        { Id: 0 },
+        { Id: 1 },
+      ]);
+    });
+
     it('registers feedback with the backend', () => {
       const path = 'Status/Audio/Volume';
 


### PR DESCRIPTION
Simple, albeit a bit unorthodox solution to #33. I'd say this change could be snuk in as a minor update, as it doesn't break backwards compatibility.

For v5 we might want to look into changing the return type of `on`, but this might also be "good enough(tm)".