### PR TITLE
Browser websocket support

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "npm": ">=5.x"
   },
   "main": "lib/index.js",
+  "browser": "lib/browser.js",
   "bin": {
     "jsxapi": "./lib/cli.js"
   },

--- a/src/browser.js
+++ b/src/browser.js
@@ -1,0 +1,48 @@
+/* eslint-env browser */
+
+import Url from 'url-parse';
+
+import log from './log';
+import XAPI from './xapi';
+import WSBackend from './backend/ws';
+import websocketConnect from './transport/ws';
+
+function initBackend(opts) {
+  const { protocol } = opts;
+  switch (protocol) {
+    case '':
+    case 'ws:':
+    case 'wss:': {
+      const transport = websocketConnect(WebSocket, opts);
+      return new WSBackend(transport);
+    }
+    default:
+      throw new Error(`Invalid protocol: ${protocol}`);
+  }
+}
+
+export function connect(url, options) { // eslint-disable-line import/prefer-default-export
+  if (arguments.length === 1 && typeof url === 'object') {
+    /* eslint-disable no-param-reassign */
+    options = url;
+    url = '';
+    /* eslint-enable */
+  }
+
+  const opts = Object.assign({
+    host: '',
+    password: '',
+    protocol: 'wss:',
+    username: 'admin',
+    loglevel: 'warn',
+  }, new Url(url), options);
+
+  opts.host = opts.hostname;
+  delete opts.hostname;
+
+  log.setLevel(opts.loglevel);
+  log.info('connecting to', url);
+
+  const backend = initBackend(opts);
+  return new XAPI(backend);
+}

--- a/src/browser.js
+++ b/src/browser.js
@@ -18,7 +18,7 @@ function initBackend(opts) {
   }
 }
 
-export function connect(url, options) {
+export function connect(url, options) { // eslint-disable-line import/prefer-default-export
   const opts = Object.assign({
     host: '',
     password: '',

--- a/src/browser.js
+++ b/src/browser.js
@@ -1,9 +1,6 @@
 /* eslint-env browser */
 
-import Url from 'url-parse';
-
-import log from './log';
-import XAPI from './xapi';
+import connectImpl from './connect';
 import WSBackend from './backend/ws';
 import websocketConnect from './transport/ws';
 
@@ -21,28 +18,13 @@ function initBackend(opts) {
   }
 }
 
-export function connect(url, options) { // eslint-disable-line import/prefer-default-export
-  if (arguments.length === 1 && typeof url === 'object') {
-    /* eslint-disable no-param-reassign */
-    options = url;
-    url = '';
-    /* eslint-enable */
-  }
-
+export function connect(url, options) {
   const opts = Object.assign({
     host: '',
     password: '',
     protocol: 'wss:',
     username: 'admin',
     loglevel: 'warn',
-  }, new Url(url), options);
-
-  opts.host = opts.hostname;
-  delete opts.hostname;
-
-  log.setLevel(opts.loglevel);
-  log.info('connecting to', url);
-
-  const backend = initBackend(opts);
-  return new XAPI(backend);
+  }, options);
+  return connectImpl(url, opts, initBackend);
 }

--- a/src/connect.js
+++ b/src/connect.js
@@ -1,0 +1,42 @@
+import Url from 'url-parse';
+
+import log from './log';
+import XAPI from './xapi';
+
+/**
+ * Connect to an XAPI endpoint.
+ *
+ * @example
+ * const xapi = connect('ssh://host.example.com:22');
+ *
+ * @param {string} url - Connection specification.
+ * @param {Object} [options] - Connect options.
+ * @param {string} [options.host] -
+ *     Hostname to connect to.
+ * @param {string} [options.username] -
+ *     Username to authenticate with if protocol requires authentication.
+ * @param {string} [options.password] -
+ *     Password to authenticate with if protocol requires authentication.
+ * @param {string} [options.loglevel] -
+ *     Set the internal log level.
+ * @return {XAPI} - XAPI interface connected to the given URI.
+ */
+export default function connect(url, options, initBackend) { // eslint-disable-line import/prefer-default-export
+  if (arguments.length === 1 && typeof url === 'object') {
+    /* eslint-disable no-param-reassign */
+    options = url;
+    url = '';
+    /* eslint-enable */
+  }
+
+  const opts = Object.assign({}, new Url(url), options);
+
+  opts.host = opts.hostname;
+  delete opts.hostname;
+
+  log.setLevel(opts.loglevel);
+  log.info('connecting to', url);
+
+  const backend = initBackend(opts);
+  return new XAPI(backend);
+}

--- a/src/connect.js
+++ b/src/connect.js
@@ -21,7 +21,7 @@ import XAPI from './xapi';
  *     Set the internal log level.
  * @return {XAPI} - XAPI interface connected to the given URI.
  */
-export default function connect(url, options, initBackend) { // eslint-disable-line import/prefer-default-export
+export default function connect(url, options, initBackend) {
   if (arguments.length === 1 && typeof url === 'object') {
     /* eslint-disable no-param-reassign */
     options = url;

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,7 @@
-import Url from 'url-parse';
 import WebSocket from 'ws';
 
-import log from './log';
+import connectImpl from './connect';
 import connectSSH from './transport/ssh';
-import XAPI from './xapi';
 import TSHBackend from './backend/tsh';
 import WSBackend from './backend/ws';
 import spawnTSH from './transport/tsh';
@@ -32,49 +30,13 @@ function initBackend(opts) {
   }
 }
 
-
-/**
- * Connect to an XAPI endpoint.
- *
- * @example
- * const xapi = connect('ssh://host.example.com:22');
- *
- * @param {string} url - Connection specification.
- * @param {Object} [options] - Connect options.
- * @param {string} [options.host] -
- *     Hostname to connect to.
- * @param {string} [options.username] -
- *     Username to authenticate with if protocol requires authentication.
- * @param {string} [options.password] -
- *     Password to authenticate with if protocol requires authentication.
- * @param {string} [options.loglevel] -
- *     Set the internal log level.
- * @return {XAPI} - XAPI interface connected to the given URI.
- */
-export function connect(url, options) { // eslint-disable-line import/prefer-default-export
-  if (arguments.length === 1 && typeof url === 'object') {
-    /* eslint-disable no-param-reassign */
-    options = url;
-    url = '';
-    /* eslint-enable */
-  }
-
-  const parsedUrl = new Url(url.match(/^\w+:\/\//) ? url : `ssh://${url}`);
-
+export function connect(url, options) {
   const opts = Object.assign({
     host: '',
     password: '',
     protocol: 'ssh:',
     username: 'admin',
     loglevel: 'warn',
-  }, parsedUrl, options);
-
-  opts.host = opts.hostname;
-  delete opts.hostname;
-
-  log.setLevel(opts.loglevel);
-  log.info('connecting to', url);
-
-  const backend = initBackend(opts);
-  return new XAPI(backend);
+  }, options);
+  return connectImpl(url, opts, initBackend);
 }

--- a/src/index.js
+++ b/src/index.js
@@ -7,29 +7,7 @@ import XAPI from './xapi';
 import TSHBackend from './backend/tsh';
 import WSBackend from './backend/ws';
 import spawnTSH from './transport/tsh';
-
-
-function generateAuthSubProto(username, password) {
-  const authHash = Buffer
-    .from(`${username}:${password}`)
-    .toString('base64')
-    .replace(/[/+=]/g, c => ({ '+': '-', '/': '_', '=': '' }[c]));
-  return `auth-${authHash}`;
-}
-
-
-function websocketConnect({ host, username, password, protocol }) {
-  const url = new Url();
-  url.set('pathname', '/ws');
-  url.set('host', host);
-  url.set('protocol', protocol);
-
-  const auth = generateAuthSubProto(username, password);
-  return new WebSocket(url.href, auth, {
-    followRedirects: true,
-    rejectUnauthorized: false,
-  });
-}
+import websocketConnect from './transport/ws';
 
 
 function initBackend(opts) {
@@ -46,7 +24,7 @@ function initBackend(opts) {
     }
     case 'ws:':
     case 'wss:': {
-      const transport = websocketConnect(opts);
+      const transport = websocketConnect(WebSocket, opts);
       return new WSBackend(transport);
     }
     default:

--- a/src/index.js
+++ b/src/index.js
@@ -30,7 +30,7 @@ function initBackend(opts) {
   }
 }
 
-export function connect(url, options) {
+export function connect(url, options) { // eslint-disable-line import/prefer-default-export
   const opts = Object.assign({
     host: '',
     password: '',

--- a/src/transport/ws.js
+++ b/src/transport/ws.js
@@ -1,0 +1,27 @@
+import Url from 'url-parse';
+
+function base64Enc(input) {
+  return (typeof btoa === 'function')
+    ? btoa(input) // eslint-disable-line no-undef
+    : Buffer.from(input).toString('base64');
+}
+
+function generateAuthSubProto(username, password) {
+  const authHash = base64Enc(`${username}:${password}`)
+    .replace(/[/+=]/g, c => ({ '+': '-', '/': '_', '=': '' }[c]));
+  return `auth-${authHash}`;
+}
+
+export default function websocketConnect(WebSocket, opts) {
+  const { host, username, password, protocol } = opts;
+  const url = new Url();
+  url.set('pathname', '/ws');
+  url.set('host', host);
+  url.set('protocol', protocol);
+
+  const auth = generateAuthSubProto(username, password);
+  return new WebSocket(url.href, auth, {
+    followRedirects: true,
+    rejectUnauthorized: false,
+  });
+}


### PR DESCRIPTION
Provide a separate entry point for browsers, to avoid bundlers pulling in `node`-only dependencies. Most of the connection logic is the same as for `ws` on the `node` side, except for some different defaults, supported protocols and means of encoding `base64` for the sub-protocol auth.