### PR TITLE
xapi: Add version attribute to XAPI instance

### DIFF
--- a/package.d.ts
+++ b/package.d.ts
@@ -1,0 +1,4 @@
+export default package;
+export const package: {
+  version: string;
+};

--- a/package.js
+++ b/package.js
@@ -1,0 +1,8 @@
+const fs = require('fs');
+
+function readPkg() {
+  const data = fs.readFileSync(__dirname + '/package.json', 'utf8');
+  return JSON.parse(data);
+}
+
+module.exports = readPkg();

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,18 +3,12 @@
 import commander from 'commander';
 
 import * as fs from 'fs';
-import * as path from 'path';
 import * as REPL from 'repl';
 
 import { connect } from './';
 import log from './log';
 import XAPI from './xapi/index.js';
-
-function readPkg() {
-  const filepath = path.join(__dirname, '..', 'package.json');
-  const data = fs.readFileSync(filepath, 'utf8');
-  return JSON.parse(data);
-}
+import pkg from '../package.js';
 
 function evalFile(source: any, xapi: XAPI) {
   const context = new Function('xapi', source);
@@ -33,9 +27,8 @@ function startRepl(xapi: XAPI) {
  * See [[Options]] for options.
  */
 function main() {
-  const { version } = readPkg();
   commander
-    .version(version)
+    .version(pkg.version)
     .arguments('<host> [file]')
     .description('connect to a codec and launch a repl')
     .option('-p, --port <port>', 'port to connect to', 22)

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,10 +5,10 @@ import commander from 'commander';
 import * as fs from 'fs';
 import * as REPL from 'repl';
 
+import pkg from '../package.js';
 import { connect } from './';
 import log from './log';
 import XAPI from './xapi/index.js';
-import pkg from '../package.js';
 
 function evalFile(source: any, xapi: XAPI) {
   const context = new Function('xapi', source);

--- a/src/xapi/index.ts
+++ b/src/xapi/index.ts
@@ -4,8 +4,8 @@ import log from '../log';
 import normalizePath from './normalizePath';
 import * as rpc from './rpc';
 
-import { Backend } from '../backend';
 import pkg from '../../package.js';
+import { Backend } from '../backend';
 import { Config, Event, Status } from './components';
 import Feedback from './feedback';
 import createXapiProxy from './proxy';

--- a/src/xapi/index.ts
+++ b/src/xapi/index.ts
@@ -5,6 +5,7 @@ import normalizePath from './normalizePath';
 import * as rpc from './rpc';
 
 import { Backend } from '../backend';
+import pkg from '../../package.js';
 import { Config, Event, Status } from './components';
 import Feedback from './feedback';
 import createXapiProxy from './proxy';
@@ -96,6 +97,8 @@ export declare interface XAPI {
  * ```
  */
 export class XAPI extends EventEmitter {
+  public version: string = pkg.version;
+
   public feedback: Feedback;
   public config: Config;
   public status: Status;


### PR DESCRIPTION
Add `version` attribute to the `XAPI` instance for *some* introspection. This should work in both `nodejs` and the browser bundle. `parcel` resolves `readFileSync` calls and inlines the data if it manages to resolve the path at build time.

I won't accept any solution which relies on any manual process to ensure the version number is correct in code. This was the least crappy way I managed to resolve this. Several other options resulted in dead-ends, mostly because of `TypeScript` (`--resolveJsonModule` messed with the output directory structure), or `TypeScript` in `Parcel` (https://github.com/parcel-bundler/parcel/issues/1736).
