### PR TITLE
Fix duplicate websocket feedback

### DIFF
--- a/src/xapi/feedback.ts
+++ b/src/xapi/feedback.ts
@@ -184,14 +184,17 @@ export default class Feedback {
       .join('/')
       .toLowerCase();
 
-    this.eventEmitter.on(eventPath, listener);
-
     const registration = this.xapi.execute<FeedbackId>('xFeedback/Subscribe', {
       Query: normalizePath(path),
     });
 
+    const idP = registration.then(({ Id }) => {
+      this.eventEmitter.on(eventPath, listener);
+      return Id;
+    });
+
     const off = () => {
-      registration.then(({ Id }) => {
+      idP.then((Id) => {
         this.xapi.execute('xFeedback/Unsubscribe', { Id });
       });
 

--- a/src/xapi/feedback.ts
+++ b/src/xapi/feedback.ts
@@ -23,7 +23,7 @@ export type FeedbackInterceptor =
  * Type representing a feedback id.
  */
 interface FeedbackId {
-  Id: string;
+  Id: number;
 }
 
 /**
@@ -106,7 +106,7 @@ function dispatch(
   }
 
   const emitPath = path.join('/').toLowerCase();
-  feedback.eventEmitter.emit(emitPath, data, root);
+  feedback.eventEmitter.emit(emitPath, data, root, root.Id);
 
   if (typeof data === 'object') {
     Object.keys(data).forEach((key) => {
@@ -188,17 +188,29 @@ export default class Feedback {
       Query: normalizePath(path),
     });
 
+    let wrapper: <T = any>(ev: T, root: any, id?: number) => void;
+
     const idP = registration.then(({ Id }) => {
-      this.eventEmitter.on(eventPath, listener);
+      wrapper = (ev, root, id) => {
+        if (typeof id !== 'undefined' && id !== Id) {
+          return;
+        }
+        listener(ev, root);
+      };
+      this.eventEmitter.on(eventPath, wrapper);
       return Id;
     });
 
     const off = () => {
+      if (!wrapper) {
+        return;
+      }
+
       idP.then((Id) => {
         this.xapi.execute('xFeedback/Unsubscribe', { Id });
       });
 
-      this.eventEmitter.removeListener(eventPath, listener);
+      this.eventEmitter.removeListener(eventPath, wrapper);
     };
 
     off.registration = registration;

--- a/test/xapi/feedback.spec.ts
+++ b/test/xapi/feedback.spec.ts
@@ -121,6 +121,24 @@ describe('Feedback', () => {
 
       expect(spy).toHaveBeenCalledWith('True', data);
     });
+
+    it('fires only on matching Id', async () => {
+      const spy1 = jest.fn();
+      const spy2 = jest.fn();
+
+      await Promise.all([
+        feedback.on('Status/Audio/Volume', spy1).registration,
+        feedback.on('Status/Audio/Volume', spy2).registration,
+      ]);
+
+      feedback.dispatch({
+        Id: 0,
+        Status: { Audio: { Volume: '50' } },
+      });
+
+      expect(spy1).toHaveBeenCalledTimes(1);
+      expect(spy2).not.toHaveBeenCalled();
+    });
   });
 
   describe('.on()', () => {

--- a/test/xapi/feedback.spec.ts
+++ b/test/xapi/feedback.spec.ts
@@ -58,22 +58,25 @@ describe('Feedback', () => {
       expect(feedback.dispatch({ Status: 'foo' })).toEqual(feedback);
     });
 
-    it('fires event', () => {
+    it('fires event', async () => {
       const spy = jest.fn();
-      feedback.on('Status', spy);
+      await feedback.on('Status', spy).registration;
       feedback.dispatch({ Status: 'foo' });
       expect(spy).toHaveBeenCalledTimes(1);
       expect(spy).toHaveBeenCalledWith('foo', expect.anything());
     });
 
-    it('fires events recursively', () => {
+    it('fires events recursively', async () => {
       const data = { Status: { Audio: { Volume: '50' } } };
       const spies = [jest.fn(), jest.fn(), jest.fn(), jest.fn()];
 
-      feedback.on('', spies[0]);
-      feedback.on('Status', spies[1]);
-      feedback.on('Status/Audio', spies[2]);
-      feedback.on('Status/Audio/Volume', spies[3]);
+      await Promise.all([
+        feedback.on('', spies[0]).registration,
+        feedback.on('Status', spies[1]).registration,
+        feedback.on('Status/Audio', spies[2]).registration,
+        feedback.on('Status/Audio/Volume', spies[3]).registration,
+      ]);
+
       feedback.dispatch(data);
 
       [data, data.Status, data.Status.Audio, data.Status.Audio.Volume].forEach(
@@ -83,12 +86,15 @@ describe('Feedback', () => {
       );
     });
 
-    it('does not invoke unrelated handlers', () => {
+    it('does not invoke unrelated handlers', async () => {
       const spy1 = jest.fn();
       const spy2 = jest.fn();
 
-      feedback.on('Status/Audio/Volume', spy1);
-      feedback.on('Status/Audio/VolumeMute', spy2);
+      await Promise.all([
+        feedback.on('Status/Audio/Volume', spy1).registration,
+        feedback.on('Status/Audio/VolumeMute', spy2).registration,
+      ]);
+
       feedback.dispatch({ Status: { Audio: { VolumeMute: 'off' } } });
 
       expect(spy1).not.toHaveBeenCalled();
@@ -96,21 +102,21 @@ describe('Feedback', () => {
       expect(spy2).toHaveBeenCalledWith('off', expect.anything());
     });
 
-    it('dispatches original feedback payload as second argument', () => {
+    it('dispatches original feedback payload as second argument', async () => {
       const spy = jest.fn();
       const data = { Status: { Call: [{ id: 42, Status: 'Connected' }] } };
 
-      feedback.on('Status/Call/Status', spy);
+      await feedback.on('Status/Call/Status', spy).registration;
       feedback.dispatch(data);
 
       expect(spy).toHaveBeenCalledWith('Connected', data);
     });
 
-    it('can listen to lower-case events', () => {
+    it('can listen to lower-case events', async () => {
       const spy = jest.fn();
       const data = { Status: { Call: [{ id: 42, ghost: 'True' }] } };
 
-      feedback.on('Status/Call/ghost', spy);
+      await feedback.on('Status/Call/ghost', spy).registration;
       feedback.dispatch(data);
 
       expect(spy).toHaveBeenCalledWith('True', data);
@@ -118,19 +124,20 @@ describe('Feedback', () => {
   });
 
   describe('.on()', () => {
-    it('registers handler for events', () => {
+    it('registers handler for events', async () => {
       const spy = jest.fn();
 
-      feedback.on('Status/Audio/Volume', spy);
+      await feedback.on('Status/Audio/Volume', spy).registration;
       feedback.dispatch({ Status: { Audio: { Volume: 50 } } });
 
       expect(spy).toHaveBeenCalledWith(50, expect.anything());
     });
 
-    it('returns handler for disabling feedback', () => {
+    it('returns handler for disabling feedback', async () => {
       const spy = jest.fn();
 
       const handler = feedback.on('Status/Audio/Volume', spy);
+      await handler.registration;
       feedback.dispatch({ Status: { Audio: { Volume: 50 } } });
 
       expect(spy).toHaveBeenCalledWith(50, expect.anything());
@@ -163,12 +170,13 @@ describe('Feedback', () => {
       });
     });
 
-    it('cancelling double registration leaves one listener', () => {
+    it('cancelling double registration leaves one listener', async () => {
       const spy = jest.fn();
       const path = 'Status/Audio/Volume';
 
-      feedback.on(path, spy);
+      await feedback.on(path, spy).registration;
       const off = feedback.on(path, spy);
+      await off.registration;
       off();
 
       feedback.dispatch({ Status: { Audio: { Volume: 50 } } });
@@ -187,34 +195,37 @@ describe('Feedback', () => {
       });
     });
 
-    it('can dispatch to normalized path', () => {
+    it('can dispatch to normalized path', async () => {
       const spy = jest.fn();
 
-      feedback.on('status/audio   volume', spy);
+      await feedback.on('status/audio   volume', spy).registration;
       feedback.dispatch({ Status: { Audio: { Volume: 50 } } });
 
       expect(spy).toHaveBeenNthCalledWith(1, 50, expect.anything());
     });
 
-    it('can use crazy casing', () => {
+    it('can use crazy casing', async () => {
       const spy = jest.fn();
 
-      feedback.on('fOO Bar BaZ', spy);
+      await feedback.on('fOO Bar BaZ', spy).registration;
       feedback.dispatch({ Foo: { Bar: { Baz: 50 } } });
 
       expect(spy).toHaveBeenNthCalledWith(1, 50, expect.anything());
     });
 
-    it('handles arrays', () => {
+    it('handles arrays', async () => {
       const spy1 = jest.fn();
       const spy2 = jest.fn();
       const spy3 = jest.fn();
       const spy4 = jest.fn();
 
-      feedback.on('Status/Peripherals/ConnectedDevice/Status', spy1);
-      feedback.on('Status/Peripherals/ConnectedDevice[]/Status', spy2);
-      feedback.on('Status/Peripherals/ConnectedDevice/1115/Status', spy3);
-      feedback.on('Status/Peripherals/ConnectedDevice[1115]/Status', spy4);
+      await Promise.all([
+        feedback.on('Status/Peripherals/ConnectedDevice/Status', spy1).registration,
+        feedback.on('Status/Peripherals/ConnectedDevice[]/Status', spy2).registration,
+        feedback.on('Status/Peripherals/ConnectedDevice/1115/Status', spy3).registration,
+        feedback.on('Status/Peripherals/ConnectedDevice[1115]/Status', spy4).registration,
+      ]);
+
       feedback.dispatch({
         Status: {
           Peripherals: {
@@ -241,10 +252,10 @@ describe('Feedback', () => {
       expect(spy4).not.toHaveBeenCalledWith('Connected', expect.anything());
     });
 
-    it('dispatches array elements one-by-one', () => {
+    it('dispatches array elements one-by-one', async () => {
       const spy = jest.fn();
 
-      feedback.on('foo/bar', spy);
+      await feedback.on('foo/bar', spy).registration;
 
       feedback.dispatch({
         foo: { bar: [{ baz: 'quux' }] },
@@ -254,10 +265,13 @@ describe('Feedback', () => {
       expect(spy).toHaveBeenCalledWith({ baz: 'quux' }, expect.anything());
     });
 
-    it('handles ghost events', () => {
+    it('handles ghost events', async () => {
       const spy = jest.fn();
 
-      feedback.on('Status/Peripherals/ConnectedDevice', spy);
+      await feedback
+        .on('Status/Peripherals/ConnectedDevice', spy)
+        .registration;
+
       feedback.dispatch({
         Status: {
           Peripherals: {
@@ -296,10 +310,11 @@ describe('Feedback', () => {
   });
 
   describe('.once()', () => {
-    it('deregisters after emit', () => {
+    it('deregisters after emit', async () => {
       const spy = jest.fn();
 
-      feedback.once('Status/Audio/Volume', spy);
+      await feedback.once('Status/Audio/Volume', spy).registration;
+
       feedback.dispatch({ Status: { Audio: { Volume: '50' } } });
       feedback.dispatch({ Status: { Audio: { Volume: '70' } } });
 
@@ -328,7 +343,7 @@ describe('Feedback', () => {
       interceptor.mockReset();
     });
 
-    it('can reject feedback', () => {
+    it('can reject feedback', async () => {
       const volumeSpy = jest.fn();
       const data = { Status: { Audio: { Volume: '50' } } };
 
@@ -338,7 +353,7 @@ describe('Feedback', () => {
           fn();
         });
 
-      feedback.on('Status Audio Volume', volumeSpy);
+      await feedback.on('Status Audio Volume', volumeSpy).registration;
 
       feedback.dispatch(data);
       expect(volumeSpy).not.toHaveBeenCalled();
@@ -348,7 +363,7 @@ describe('Feedback', () => {
       expect(volumeSpy).toHaveBeenCalledWith('50', data);
     });
 
-    it('can change the data', () => {
+    it('can change the data', async () => {
       const spy = jest.fn();
 
       interceptor.mockImplementation(
@@ -361,7 +376,7 @@ describe('Feedback', () => {
         },
       );
 
-      feedback.on('Status Audio Volume', spy);
+      await feedback.on('Status Audio Volume', spy).registration;
 
       const data = { Status: { Audio: { Volume: '50' } } };
       feedback.dispatch(data);
@@ -399,9 +414,9 @@ describe('Feedback', () => {
       expect(muteSpy).toHaveBeenNthCalledWith(1, 'On', expect.anything());
     });
 
-    it('only deregisters feedback of the group', () => {
+    it('only deregisters feedback of the group', async () => {
       const rootSpy = jest.fn();
-      xapi.status.on('Audio/Volume', rootSpy);
+      await xapi.status.on('Audio/Volume', rootSpy).registration;
 
       group.off();
 
@@ -419,11 +434,15 @@ describe('Feedback', () => {
       expect(muteSpy).not.toHaveBeenCalled();
     });
 
-    it('supports .once()', () => {
+    it('supports .once()', async () => {
       const spy = jest.fn();
 
       group.off();
-      group.add(xapi.status.once('Audio/Volume', spy));
+
+      const subscription = xapi.status.once('Audio/Volume', spy);
+      group.add(subscription);
+
+      await subscription.registration;
 
       feedback.dispatch({ Status: { Audio: { Volume: '50' } } });
       feedback.dispatch({ Status: { Audio: { Volume: '70' } } });

--- a/test/xapi/index.spec.ts
+++ b/test/xapi/index.spec.ts
@@ -1,6 +1,6 @@
 import Backend from '../../src/backend';
 import XAPI from '../../src/xapi';
-import { XapiRequest, XapiResult } from '../../src/xapi/types';
+import { XapiRequest } from '../../src/xapi/types';
 import { METHOD_NOT_FOUND } from '../../src/xapi/exc';
 
 describe('XAPI', () => {


### PR DESCRIPTION
This fixes an issue where feedback handlers are invoked multiple times if there are duplicate feedback registrations.

Given a test (`test.js`) script of:

```javascript
xapi.event.on('Message Send', (message) => {
  console.log(`message 1 is: ${message.Text}`);
});

xapi.event.on('Message Send', (message) => {
  console.log(`message 2 is: ${message.Text}`);
});

const sendMessage = async () => {
  console.log('---');
  const Text = `Hello, time is ${new Date()}`;
  await xapi.Command.Message.Send({ Text });
  setTimeout(sendMessage, 2000);
};

sendMessage();
```

And running this before this change would result in:

```
$ jsxapi wss://host.example.com ./test.js
---
message 1 is: Hello, time is Wed Mar 11 2020 22:09:19 GMT+0100 (Central European Standard Time)
message 2 is: Hello, time is Wed Mar 11 2020 22:09:19 GMT+0100 (Central European Standard Time)
message 1 is: Hello, time is Wed Mar 11 2020 22:09:19 GMT+0100 (Central European Standard Time)
message 2 is: Hello, time is Wed Mar 11 2020 22:09:19 GMT+0100 (Central European Standard Time)
```

and after this change:

```
$ jsxapi wss://host.example.com ./test.js
---
message 1 is: Hello, time is Wed Mar 11 2020 22:10:35 GMT+0100 (Central European Standard Time)
message 2 is: Hello, time is Wed Mar 11 2020 22:10:35 GMT+0100 (Central European Standard Time)
```